### PR TITLE
Enable transition sound

### DIFF
--- a/DrakeandJoshPart1/SoundLibrary.cs
+++ b/DrakeandJoshPart1/SoundLibrary.cs
@@ -9,31 +9,27 @@ public class SoundLibrary
 
     public static void PlayTransitionSound()
     {
-        /*
-var assembly = Assembly.GetExecutingAssembly();
-    var resourceName = "DrakeandJoshPart1.Sounds.DrakeandJoshTransition.wav";
+        var assembly = Assembly.GetExecutingAssembly();
+        var resourceName = "DrakeandJoshPart1.Sounds.DrakeandJoshTransition.wav";
 
-    using Stream stream = assembly.GetManifestResourceStream(resourceName);
-    if (stream != null)
-    {
-        SoundPlayer player = new SoundPlayer(stream);
-        player.Play();
+        using Stream? stream = assembly.GetManifestResourceStream(resourceName);
+        if (stream != null)
+        {
+            SoundPlayer player = new SoundPlayer(stream);
+            player.Play();
+        }
+        else
+        {
+            System.Windows.Forms.MessageBox.Show($"Sound resource not found: {resourceName}");
+        }
+
+        // Print out all the resources in the assembly
+        foreach (var name in Assembly.GetExecutingAssembly().GetManifestResourceNames())
+        {
+            Console.WriteLine("RESOURCE: " + name);
+        }
+
     }
-    else
-    {
-        System.Windows.Forms.MessageBox.Show($"Sound resource not found: {resourceName}");
-    }
-
-    // Print out all the resources in the assembly
-
-    foreach (var name in Assembly.GetExecutingAssembly().GetManifestResourceNames())
-    {
-        Console.WriteLine("RESOURCE: " + name);
-
-    }
-*/
-
-}
 
     
 }


### PR DESCRIPTION
## Summary
- re-enable `SoundLibrary.PlayTransitionSound` so the embedded WAV resource plays

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68730edd5bec832e8fc32be31b437e64